### PR TITLE
Changed "ui.background" = "#ffffff".

### DIFF
--- a/oxocarbon.toml
+++ b/oxocarbon.toml
@@ -29,7 +29,7 @@
 "diff.minus" = { fg = "#78a9ff", bg = "#393939" }
 "diff.delta" = { fg = "#dde1e6", bg = "#262626" }
 
-"ui.background" = "#161616"
+"ui.background" = "#ffffff"
 "ui.separator" = "#161616"
 "ui.selection" = { bg = "#393939"}
 "ui.text" = { fg = "#ffffff" }


### PR DESCRIPTION
This makes terminal ui borders display correctly.

## Before: 
<img width="842" alt="ui-before" src="https://github.com/neoangelism/oxocarbon-helix/assets/74485456/5084d1f4-2abf-4a4a-adb4-50dde8eb480f">

## After:
<img width="841" alt="ui-after" src="https://github.com/neoangelism/oxocarbon-helix/assets/74485456/53ac9ac5-2002-4423-a9aa-b94db04f035f">
