### PR TITLE
Fix bug when using light theme'd terminal.

### DIFF
--- a/oxocarbon.toml
+++ b/oxocarbon.toml
@@ -29,7 +29,7 @@
 "diff.minus" = { fg = "#78a9ff", bg = "#393939" }
 "diff.delta" = { fg = "#dde1e6", bg = "#262626" }
 
-"ui.background" = "#ffffff"
+"ui.background" = { fg= "#ffffff", bg = "#161616"}
 "ui.separator" = "#161616"
 "ui.selection" = { bg = "#393939"}
 "ui.text" = { fg = "#ffffff" }


### PR DESCRIPTION
Using only "ui.background" = "#ffffff" breaks when using light theme on terminal apps. 
This has been fixed with using fg and bg. Theme now looks good on both dark and light terminals.

Sorry about that!